### PR TITLE
Feat/help: `help` command 구현

### DIFF
--- a/cmd/help.go
+++ b/cmd/help.go
@@ -1,0 +1,40 @@
+/*
+Copyright © 2025 NAME HERE <EMAIL ADDRESS>
+
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// helpCmd represents the help command
+var helpCmd = &cobra.Command{
+	Use:   "help",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("help called")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(helpCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// helpCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// helpCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -1,6 +1,5 @@
 /*
 Copyright © 2025 NAME HERE <EMAIL ADDRESS>
-
 */
 package cmd
 
@@ -13,15 +12,27 @@ import (
 // helpCmd represents the help command
 var helpCmd = &cobra.Command{
 	Use:   "help",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "도움말 보기",
+	Long:  "모든 명령어와 사용법을 요약해서 출력합니다.",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("help called")
+		fmt.Println(`morama 0.1.0
+영화·드라마 기록 CLI
+
+Usage:
+  morama [command]
+
+Available Commands:
+  add         기록 추가
+  delete      기록 삭제
+  edit        기록 수정
+  list        기록 목록보기
+  show        상세 후기 보기
+  report      연도/유형별 통계 출력
+  help        도움말
+
+Flags:
+  -h, --help     help for morama
+      --version  버전 정보 출력`)
 	},
 }
 


### PR DESCRIPTION
#### morama help 명령 실행 시, 고정된 포맷으로 CLI 도움말을 출력하도록 구현하였습니다 :)

**구현 과정**

1. cobra-cli add help 명령으로 기본 커맨드 생성
```
cobra-cli add help
```

2. helpCmd의 기본 템플릿 수정
Run 함수 내부에서 fmt.Println(...)을 이용해 전체 도움말을 고정된 형식으로 출력하도록 구현

3. 출력 내용
지금은 노션에 정리해둔 내용을 그대로 출력하도록 했습니다, , !
앞으로 더 좋은 방법이 있는지 공부해서 편하게 관리할 수 있는 방식으로 바꿔보겠습니다 ☺️

**결과**
```
 go run main.go help
```

![image](https://github.com/user-attachments/assets/e3ed8cb5-fd96-4cca-8670-00c547518e6d)

