### PR TITLE
🔖 Ldflags 기반 버전 출력 기능 추가

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -9,33 +9,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const version = "0.1.0"
+var version = "0.1.0" // 기본값
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
+	Short: "버전 정보를 출력합니다",
 
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(version)
+		fmt.Println("morama version", version)
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(versionCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// versionCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// versionCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }


### PR DESCRIPTION
#### 변경 내용
- morama version 명령어 실행 시 기본값 `0.1.0`이 출력되도록 설정
- go 빌드 시 `ldflags`를 이용해 외부에서 버전 값을 주입할 수 있도록 version 변수 수정


**결과**
- 기본 빌드: morama version → 0.1.0
- 태그 버전 주입하여 빌드: morama version → 1.0.0

![image](https://github.com/user-attachments/assets/c5454ba7-24a9-40c1-861b-866535016a80)

**참고 자료**
[https://www.latera.kr/blog/2021-01-01-golang-insert-build-info/](url)


**✨ Git 태그 + GitHub Actions를 활용한 자동화**
GitHub Actions를 활용해 git 태그를 기준으로 자동으로 버전을 주입하는 방식도 있다고 하는데, 도입해보면 재밌을 것 같습니다!
